### PR TITLE
Refactor UI

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,12 @@
-import { AppShell, MantineProvider, createTheme } from "@mantine/core";
+import {
+  AppShell,
+  Burger,
+  Group,
+  MantineProvider,
+  createTheme,
+} from "@mantine/core";
 import "@mantine/core/styles.css";
+import { useDisclosure } from "@mantine/hooks";
 import React, { useEffect } from "react";
 import { Route, Routes } from "react-router-dom";
 import { sendHello } from "./api/general";
@@ -14,6 +21,9 @@ import { HEADER_HEIGHT } from "./utils/constants";
 const theme = createTheme({});
 
 const App: React.FC = () => {
+  const [mobileOpened, { toggle: toggleMobile }] = useDisclosure();
+  const [desktopOpened, { toggle: toggleDesktop }] = useDisclosure(true);
+
   useEffect(() => {
     sendHello();
   }, []);
@@ -22,13 +32,33 @@ const App: React.FC = () => {
     <MantineProvider theme={theme}>
       <AppShell
         padding="md"
-        navbar={{ width: { base: 300 }, breakpoint: "sm" }}
+        navbar={{
+          width: 300,
+          breakpoint: "sm",
+          collapsed: { mobile: !mobileOpened, desktop: !desktopOpened },
+        }}
         header={{ height: HEADER_HEIGHT }}
         styles={(theme) => ({
           main: { backgroundColor: theme.colors.gray[0] },
         })}
       >
-        <AppHeader />
+        <AppShell.Header>
+          <Group h="100%" px="md">
+            <Burger
+              opened={mobileOpened}
+              onClick={toggleMobile}
+              hiddenFrom="sm"
+              size="sm"
+            />
+            <Burger
+              opened={desktopOpened}
+              onClick={toggleDesktop}
+              visibleFrom="sm"
+              size="sm"
+            />
+            <AppHeader />
+          </Group>
+        </AppShell.Header>
         <AppNavigation />
         <AppShell.Main>
           <Routes>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,7 +12,7 @@ import { Route, Routes } from "react-router-dom";
 import { sendHello } from "./api/general";
 import AppHeader from "./components/app/AppHeader";
 import AppNavigation from "./components/app/AppNavigation";
-import Compose from "./pages/Compose";
+import ComposePage from "./pages/ComposePage/ComposePage";
 import Drafts from "./pages/Drafts";
 import HomePage from "./pages/HomePage";
 import ThemeEditor from "./pages/ThemeEditor";
@@ -63,7 +63,7 @@ const App: React.FC = () => {
         <AppShell.Main>
           <Routes>
             <Route path="/" element={<HomePage />} />
-            <Route path="/compose" element={<Compose />} />
+            <Route path="/compose" element={<ComposePage />} />
             <Route path="/drafts" element={<Drafts />} />
             <Route path="/edit-theme" element={<ThemeEditor />} />
           </Routes>

--- a/src/components/app/AppHeader.tsx
+++ b/src/components/app/AppHeader.tsx
@@ -1,20 +1,16 @@
-import { AppShell, Group, Title } from "@mantine/core";
+import { Title } from "@mantine/core";
 import React from "react";
 import { Link } from "react-router-dom";
 
 const AppHeader: React.FC = () => {
   return (
-    <AppShell.Header>
-      <Group style={{ height: "100%" }} px={20} justify="space-between">
-        <Link
-          to="/"
-          // FIXME: Remove hardcoding of Tailwind prefix
-          className="tw-no-underline hover:tw-underline tw-text-black"
-        >
-          <Title>glam-mailer</Title>
-        </Link>
-      </Group>
-    </AppShell.Header>
+    <Link
+      to="/"
+      // FIXME: Remove hardcoding of Tailwind prefix
+      className="tw-no-underline hover:tw-underline tw-text-black"
+    >
+      <Title>glam-mailer</Title>
+    </Link>
   );
 };
 

--- a/src/pages/ComposePage/ComposePage.tsx
+++ b/src/pages/ComposePage/ComposePage.tsx
@@ -20,17 +20,17 @@ import {
   HiOutlinePencilSquare,
 } from "react-icons/hi2";
 import ReactToPrint from "react-to-print";
-import SAMPLE_MARKDOWN_CONTENT from "../assets/md-sample.md?raw";
-import Editor from "../components/common/Editor";
-import Markdown from "../components/common/Markdown";
-import { PLACEHOLDER_MARKDOWN_CONTENT } from "../utils/constants";
-import { MAIL_PROVIDERS } from "../utils/mail";
-import { formatAsHtmlEmail, getTheme } from "../utils/theme";
+import SAMPLE_MARKDOWN_CONTENT from "../../assets/md-sample.md?raw";
+import Editor from "../../components/common/Editor";
+import Markdown from "../../components/common/Markdown";
+import { PLACEHOLDER_MARKDOWN_CONTENT } from "../../utils/constants";
+import { MAIL_PROVIDERS } from "../../utils/mail";
+import { formatAsHtmlEmail, getTheme } from "../../utils/theme";
 
 import "ace-builds/src-noconflict/ext-language_tools";
 import "ace-builds/src-noconflict/mode-markdown";
 
-const Compose: React.FC = () => {
+const ComposePage: React.FC = () => {
   const [editorValue, setEditorValue] = useState(PLACEHOLDER_MARKDOWN_CONTENT);
   const ref = useRef<HTMLDivElement>(null);
 
@@ -181,4 +181,4 @@ const Compose: React.FC = () => {
   );
 };
 
-export default Compose;
+export default ComposePage;

--- a/src/pages/ComposePage/ComposePage.tsx
+++ b/src/pages/ComposePage/ComposePage.tsx
@@ -1,34 +1,23 @@
 import {
-  Box,
   Button,
   Divider,
   Group,
-  Menu,
   Notification,
   SimpleGrid,
   Space,
-  Text,
-  Title,
 } from "@mantine/core";
-import React, { useCallback, useRef, useState } from "react";
-import {
-  HiOutlineArrowTopRightOnSquare,
-  HiOutlineBackspace,
-  HiOutlineDocumentDuplicate,
-  HiOutlineDocumentText,
-  HiOutlinePaperAirplane,
-  HiOutlinePencilSquare,
-} from "react-icons/hi2";
-import ReactToPrint from "react-to-print";
+import React, { useRef, useState } from "react";
+import { HiOutlineBackspace, HiOutlineDocumentText } from "react-icons/hi2";
 import SAMPLE_MARKDOWN_CONTENT from "../../assets/md-sample.md?raw";
 import Editor from "../../components/common/Editor";
 import Markdown from "../../components/common/Markdown";
 import { PLACEHOLDER_MARKDOWN_CONTENT } from "../../utils/constants";
-import { MAIL_PROVIDERS } from "../../utils/mail";
-import { formatAsHtmlEmail, getTheme } from "../../utils/theme";
+import { getTheme } from "../../utils/theme";
 
 import "ace-builds/src-noconflict/ext-language_tools";
 import "ace-builds/src-noconflict/mode-markdown";
+import ComposePageHeader from "./ComposePageHeader";
+import ComposePageMenu from "./ComposePageMenu";
 
 const ComposePage: React.FC = () => {
   const [editorValue, setEditorValue] = useState(PLACEHOLDER_MARKDOWN_CONTENT);
@@ -37,54 +26,12 @@ const ComposePage: React.FC = () => {
   const [isFormatting, setIsFormatting] = useState(false);
 
   const theme = getTheme();
-
-  const handleCopyToClipboard = useCallback(async () => {
-    const e = ref.current;
-    if (!e) {
-      return;
-    }
-
-    setIsFormatting(true);
-    const html = e.innerHTML;
-    const formattedHtml = await formatAsHtmlEmail(html);
-    navigator.clipboard
-      .write([
-        new ClipboardItem({
-          "text/html": new Blob([formattedHtml], { type: "text/html" }),
-          "text/plain": new Blob([formattedHtml], { type: "text/plain" }),
-        }),
-      ])
-      .then(() => {
-        setIsFormatting(false);
-        alert("Copied to clipboard!");
-      })
-      .catch(() => {
-        setIsFormatting(false);
-        alert("Something went wrong.");
-      });
-  }, [ref]);
-
   return (
     <div>
       <SimpleGrid cols={2}>
         <div>
-          <Title order={2}>
-            <Group>
-              <HiOutlinePencilSquare /> Let's create an email!
-            </Group>
-          </Title>
-          <Space h="md" />
-          <Text>Let's streamline the process of creating your message.</Text>
-          <Space h="md" />
-          <Text>
-            Simply type your message below. Focus on the content – don't worry
-            about styling, we will theme it. You can utilize Markdown to add
-            formatting and structure to your message.
-          </Text>
-          <Space h="md" />
-          <Text>Unsure of what's supported? Load the example below!</Text>
-          <Space h="md" />
-          <Box style={{ display: "flex", justifyContent: "space-between" }}>
+          <ComposePageHeader />
+          <Group mt="md" justify="space-between">
             <Button
               rightSection={<HiOutlineDocumentText />}
               onClick={() => setEditorValue(SAMPLE_MARKDOWN_CONTENT)}
@@ -98,7 +45,7 @@ const ComposePage: React.FC = () => {
             >
               Clear All
             </Button>
-          </Box>
+          </Group>
           <Divider
             my="sm"
             variant="dashed"
@@ -112,48 +59,7 @@ const ComposePage: React.FC = () => {
           />
         </div>
         <div>
-          <Menu>
-            <Menu.Target>
-              <Button rightSection={<HiOutlinePaperAirplane />}>
-                Send Message
-              </Button>
-            </Menu.Target>
-
-            <Menu.Dropdown>
-              <Menu.Label>Send via (coming soon)</Menu.Label>
-              {MAIL_PROVIDERS.map((provider) => {
-                const ProviderIcon = provider.icon;
-                return (
-                  <Menu.Item
-                    disabled // TODO: Remove when ready
-                    key={provider.label}
-                    leftSection={
-                      <ProviderIcon color={false && provider.color} />
-                    }
-                  >
-                    {provider.label}
-                  </Menu.Item>
-                );
-              })}
-              <Menu.Divider />
-              <Menu.Label>Manual send</Menu.Label>
-              <Menu.Item
-                leftSection={<HiOutlineDocumentDuplicate />}
-                onClick={() => handleCopyToClipboard()}
-              >
-                Copy to clipboard
-              </Menu.Item>
-              <ReactToPrint
-                pageStyle=""
-                trigger={() => (
-                  <Menu.Item leftSection={<HiOutlineArrowTopRightOnSquare />}>
-                    Save as PDF
-                  </Menu.Item>
-                )}
-                content={() => ref.current}
-              />
-            </Menu.Dropdown>
-          </Menu>
+          <ComposePageMenu sourceRef={ref} loadingCallback={setIsFormatting} />
           {isFormatting && (
             <>
               <Space h="md" />

--- a/src/pages/ComposePage/ComposePageHeader.tsx
+++ b/src/pages/ComposePage/ComposePageHeader.tsx
@@ -1,0 +1,23 @@
+import { Card, Group, Text, Title } from "@mantine/core";
+import React from "react";
+import { HiOutlinePencilSquare } from "react-icons/hi2";
+
+const ComposePageHeader: React.FC = () => {
+  return (
+    <Card shadow="lg">
+      <Title order={2} mb="lg">
+        <Group>
+          <HiOutlinePencilSquare /> Let's create an email!
+        </Group>
+      </Title>
+      <Text mb="sm">
+        Simply type your message below. Focus on the content – don't worry about
+        styling, we will theme it. You can utilize Markdown to add formatting
+        and structure to your message.
+      </Text>
+      <Text>Unsure of what's supported? Load the example below!</Text>
+    </Card>
+  );
+};
+
+export default ComposePageHeader;

--- a/src/pages/ComposePage/ComposePageMenu.tsx
+++ b/src/pages/ComposePage/ComposePageMenu.tsx
@@ -1,0 +1,87 @@
+import { Button, Menu } from "@mantine/core";
+import React from "react";
+import {
+  HiOutlineArrowTopRightOnSquare,
+  HiOutlineDocumentDuplicate,
+  HiOutlinePaperAirplane,
+} from "react-icons/hi2";
+import ReactToPrint from "react-to-print";
+import { MAIL_PROVIDERS } from "../../utils/mail.ts";
+import { formatAsHtmlEmail } from "../../utils/theme.ts";
+
+const handleCopyToClipboard = async (
+  sourceRef: React.RefObject<HTMLDivElement>,
+  loadingCallback: (loadingState: boolean) => void = () => {}
+) => {
+  const e = sourceRef.current;
+  if (!e) {
+    return;
+  }
+
+  loadingCallback(true);
+  const html = e.innerHTML;
+  const formattedHtml = await formatAsHtmlEmail(html);
+  navigator.clipboard
+    .write([
+      new ClipboardItem({
+        "text/html": new Blob([formattedHtml], { type: "text/html" }),
+        "text/plain": new Blob([formattedHtml], { type: "text/plain" }),
+      }),
+    ])
+    .then(() => alert("Copied to clipboard!"))
+    .catch((e) => {
+      alert("Something went wrong.");
+      console.error(e);
+    })
+    .finally(() => loadingCallback(false));
+};
+
+type Props = {
+  sourceRef: React.RefObject<HTMLDivElement>;
+  loadingCallback?: (loadingState: boolean) => void;
+};
+
+const ComposePageMenu: React.FC<Props> = ({ sourceRef, loadingCallback }) => {
+  return (
+    <Menu>
+      <Menu.Target>
+        <Button rightSection={<HiOutlinePaperAirplane />}>Send Message</Button>
+      </Menu.Target>
+
+      <Menu.Dropdown>
+        <Menu.Label>Send via (coming soon)</Menu.Label>
+        {MAIL_PROVIDERS.map((provider) => {
+          const ProviderIcon = provider.icon;
+          return (
+            <Menu.Item
+              disabled // TODO: Remove when ready
+              key={provider.label}
+              leftSection={<ProviderIcon color={provider.color} />}
+            >
+              {provider.label}
+            </Menu.Item>
+          );
+        })}
+        <Menu.Divider />
+        <Menu.Label>Manual send</Menu.Label>
+        <Menu.Item
+          leftSection={<HiOutlineDocumentDuplicate />}
+          onClick={() => handleCopyToClipboard(sourceRef, loadingCallback)}
+        >
+          Copy to clipboard
+        </Menu.Item>
+        <ReactToPrint
+          pageStyle=""
+          trigger={() => (
+            <Menu.Item leftSection={<HiOutlineArrowTopRightOnSquare />}>
+              Save as PDF
+            </Menu.Item>
+          )}
+          content={() => sourceRef.current}
+        />
+      </Menu.Dropdown>
+    </Menu>
+  );
+};
+
+export default ComposePageMenu;


### PR DESCRIPTION
To rebase and force-push following the merge of #89.

Changes:

* Make sidebar responsive and collapse into menu on mobile layouts
* Split "Compose" page to multiple components across different files
* Improve "Compose" page UI spacing and layout; use Mantine components where applicable
* Refactor handlers to use dependency injection